### PR TITLE
Fix PIT 1.1.6 compatibility

### DIFF
--- a/pitest-all-tests-plugin/src/main/java/org/pitest/plugins/alltests/AllTestsPrioritiserFactory.java
+++ b/pitest-all-tests-plugin/src/main/java/org/pitest/plugins/alltests/AllTestsPrioritiserFactory.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import org.pitest.classinfo.ClassName;
@@ -25,7 +26,7 @@ public class AllTestsPrioritiserFactory implements TestPrioritiserFactory {
     return "All tests prioritiser";
   }
 
-  public TestPrioritiser makeTestPrioritiser(CodeSource code,
+  public TestPrioritiser makeTestPrioritiser(Properties properties, CodeSource code,
       CoverageDatabase coverage) {
     Set<TestInfo> tis = new HashSet<TestInfo>();
     FCollection.flatMapTo(code.getCodeUnderTestNames(), classToTests(coverage), tis);

--- a/pitest-all-tests-plugin/src/test/java/org/pitest/plugins/alltests/AllTestsPrioritiserFactoryTest.java
+++ b/pitest-all-tests-plugin/src/test/java/org/pitest/plugins/alltests/AllTestsPrioritiserFactoryTest.java
@@ -6,6 +6,7 @@ import static org.pitest.classinfo.ClassName.fromString;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 import org.fest.util.Collections;
 import org.junit.Test;
@@ -33,6 +34,9 @@ public class AllTestsPrioritiserFactoryTest {
   private ClassName                  bar    = fromString("bar");
 
   @Mock
+  private Properties                 props;
+
+  @Mock
   private CodeSource                 code;
 
   @Mock
@@ -46,7 +50,7 @@ public class AllTestsPrioritiserFactoryTest {
         Arrays.asList(test("a"), test("b")));
     when(coverage.getTestsForClass(bar)).thenReturn(Arrays.asList(test("c")));
 
-    TestPrioritiser prioritiser = testee.makeTestPrioritiser(code, coverage);
+    TestPrioritiser prioritiser = testee.makeTestPrioritiser(props, code, coverage);
     List<TestInfo> actual = prioritiser.assignTests(null);
 
     assertThat(actual).containsExactly(test("a"), test("b"), test("c"));
@@ -60,7 +64,7 @@ public class AllTestsPrioritiserFactoryTest {
     when(coverage.getTestsForClass(foo)).thenReturn(Arrays.asList(test("a")));
     when(coverage.getTestsForClass(bar)).thenReturn(Arrays.asList(test("a")));
 
-    TestPrioritiser prioritiser = testee.makeTestPrioritiser(code, coverage);
+    TestPrioritiser prioritiser = testee.makeTestPrioritiser(props, code, coverage);
     List<TestInfo> actual = prioritiser.assignTests(null);
 
     assertThat(actual).containsExactly(test("a"));
@@ -75,7 +79,7 @@ public class AllTestsPrioritiserFactoryTest {
         Arrays.asList(test("z"), test("b"), test("e")));
     when(coverage.getTestsForClass(bar)).thenReturn(Arrays.asList(test("a")));
 
-    TestPrioritiser prioritiser = testee.makeTestPrioritiser(code, coverage);
+    TestPrioritiser prioritiser = testee.makeTestPrioritiser(props, code, coverage);
     List<TestInfo> actual = prioritiser.assignTests(null);
 
     assertThat(actual).containsExactly(test("a"), test("b"), test("e"),

--- a/pitest-high-isolation-plugin/src/main/java/org/pitest/plugins/isolation/HighIsolationFilterFactory.java
+++ b/pitest-high-isolation-plugin/src/main/java/org/pitest/plugins/isolation/HighIsolationFilterFactory.java
@@ -4,14 +4,15 @@ import org.pitest.classpath.CodeSource;
 import org.pitest.mutationtest.filter.MutationFilter;
 import org.pitest.mutationtest.filter.MutationFilterFactory;
 
+import java.util.Properties;
+
 public class HighIsolationFilterFactory implements MutationFilterFactory {
 
   public String description() {
     return "High isolation filter";
   }
 
-  public MutationFilter createFilter(CodeSource source, int maxMutationsPerClass) {
+  public MutationFilter createFilter(Properties properties, CodeSource source, int maxMutationsPerClass) {
     return new HighIsolationFilter();
   }
-
 }

--- a/pitest-high-isolation-plugin/src/test/java/org/pitest/plugins/isolation/HighIsolationFilterFactoryTest.java
+++ b/pitest-high-isolation-plugin/src/test/java/org/pitest/plugins/isolation/HighIsolationFilterFactoryTest.java
@@ -11,12 +11,14 @@ import org.pitest.mutationtest.config.PluginServices;
 import org.pitest.plugin.ToolClasspathPlugin;
 import org.pitest.plugins.isolation.HighIsolationFilterFactory;
 
+import java.util.Properties;
+
 public class HighIsolationFilterFactoryTest {
 
   @Test
   public void shouldCreateHighIsolationFilters() {
     HighIsolationFilterFactory testee = new HighIsolationFilterFactory();
-    assertThat(testee.createFilter(someSource(), someInt())).isNotNull();
+    assertThat(testee.createFilter(someProps(), someSource(), someInt())).isNotNull();
   }
 
   @Test
@@ -44,4 +46,7 @@ public class HighIsolationFilterFactoryTest {
     return null;
   }
 
+  private Properties someProps() {
+    return null;
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Regression functional tests in Gradle plugin detected that those plugins are incompatible with PIT 1.1.6:

```
Exception in thread "main" java.lang.AbstractMethodError: org.pitest.plugins.isolation.HighIsolationFilterFactory.createFilter(Ljava/util/Properties;Lorg/pitest/classpath/CodeSource;I)Lorg/pitest/mutationtest/filter/MutationFilter;
    at org.pitest.mutationtest.filter.CompoundFilterFactory$1.apply(CompoundFilterFactory.java:33)
    at org.pitest.mutationtest.filter.CompoundFilterFactory$1.apply(CompoundFilterFactory.java:31)
    at org.pitest.functional.FCollection.mapTo(FCollection.java:40)
    at org.pitest.functional.FCollection.map(FCollection.java:48)
    at org.pitest.mutationtest.filter.CompoundFilterFactory.createFilter(CompoundFilterFactory.java:25)
    at org.pitest.mutationtest.tooling.MutationCoverage.buildMutationTests(MutationCoverage.java:242)
    at org.pitest.mutationtest.tooling.MutationCoverage.runReport(MutationCoverage.java:133)
    at org.pitest.mutationtest.tooling.EntryPoint.execute(EntryPoint.java:105)
    at org.pitest.mutationtest.tooling.EntryPoint.execute(EntryPoint.java:46)
    at org.pitest.mutationtest.commandline.MutationCoverageReport.runReport(MutationCoverageReport.java:74)
    at org.pitest.mutationtest.commandline.MutationCoverageReport.main(MutationCoverageReport.java:45)
```
